### PR TITLE
Fix Refresh of username

### DIFF
--- a/frontend/src/Layout.js
+++ b/frontend/src/Layout.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import type { Node } from "react";
 import Toolbar from "@material-ui/core/Toolbar";
 import Typography from "@material-ui/core/Typography";
@@ -7,7 +7,7 @@ import { Link } from "@reach/router";
 import { Menu, MenuItem } from "@material-ui/core";
 import styled from "styled-components";
 import { isNil } from "ramda";
-import useApi from "./hooks/useApi";
+import useUserInfo from "./hooks/useUserInfo";
 
 const CustomToolBar = styled(Toolbar)`
   & > h6 {
@@ -41,13 +41,7 @@ export default ({ children }: Props) => {
 };
 
 const UserNavOrDefault = () => {
-  const { data: userInfo, retry } = useApi("users/name");
-
-  useEffect(() => {
-    retry();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [global.cookie]);
-
+  const { userInfo } = useUserInfo();
   const [anchorEl, setAnchorEl] = useState(null);
 
   const handleClick = e => setAnchorEl(e.currentTarget);

--- a/frontend/src/hooks/useUserInfo.js
+++ b/frontend/src/hooks/useUserInfo.js
@@ -1,0 +1,25 @@
+import { useState, useEffect } from "react";
+import useApi from "./useApi";
+
+const useLocation = () => {
+  const [location, setLocation] = useState({});
+
+  useEffect(() => {
+    setLocation(window.location);
+  }, []);
+  return { location };
+};
+
+const useUserInfo = () => {
+  const { loading, data: userInfo, error, retry } = useApi("users/name");
+  const { location } = useLocation();
+
+  useEffect(() => {
+    if (userInfo == null) retry();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.href, userInfo]);
+
+  return { loading, userInfo, error };
+};
+
+export default useUserInfo;

--- a/frontend/src/hooks/useUserInfo.test.js
+++ b/frontend/src/hooks/useUserInfo.test.js
@@ -1,0 +1,69 @@
+import React from "react";
+import { renderHook } from "@testing-library/react-hooks";
+import { render, waitForElement } from "@testing-library/react";
+import { navigate, Router } from "@reach/router";
+import useUserInfo from "./useUserInfo";
+import makeFetchReturn from "../test-utils/makeFetchReturn";
+
+const FakeInfoComponent = ({ children }) => {
+  const { loading, userInfo } = useUserInfo();
+  let name = <div>Not Logged In</div>;
+
+  if (userInfo) {
+    name = <div>{userInfo.name}</div>;
+  }
+  if (loading) {
+    name = <div>loading...</div>;
+  }
+
+  return (
+    <div>
+      {name}
+      {children}
+    </div>
+  );
+};
+
+const FakePage = () => {
+  return <div>Awesome</div>;
+};
+
+test("userInfo = null, errors = null, and loading is true when first rendered", () => {
+  const { result } = renderHook(() => useUserInfo());
+
+  const { loading, userInfo, error } = result.current;
+  expect(loading).toBe(true);
+  expect(userInfo).toBe(null);
+  expect(error).toBe(null);
+});
+
+test("userInfo is on next update", async () => {
+  makeFetchReturn({ status: 200 })({ name: "Billy Bob" });
+  const { result, waitForNextUpdate } = renderHook(() => useUserInfo());
+
+  await waitForNextUpdate();
+
+  const { userInfo } = result.current;
+  expect(userInfo).toBeDefined();
+});
+
+test("Should retry getting userInfo when changing pages", async () => {
+  makeFetchReturn({ status: 400 })({});
+  const { getByText } = render(
+    <Router>
+      <FakeInfoComponent path="/">
+        <FakePage path="/*" />
+      </FakeInfoComponent>
+    </Router>
+  );
+
+  expect(getByText(/loading/i)).toBeDefined();
+  await waitForElement(() => getByText(/Not Logged In/i));
+  makeFetchReturn({ status: 200 })({ name: "Bob Billy" });
+  navigate("/listings");
+  const userInfo = await waitForElement(() => getByText(/Bob/i));
+  expect(userInfo).toBeDefined();
+  navigate("/search/harry");
+  const userInfoAfterNavigate = getByText(/Bob/i);
+  expect(userInfoAfterNavigate).toBeDefined();
+});

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -24,7 +24,6 @@ const Login = ({ navigate }: Object) => {
               e.preventDefault();
               apiFetch("users", "POST", { email, password })
                 .then(() => {
-                  document.cookie = "auth=true";
                   navigate("/");
                 })
                 .catch(console.log);

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -1,0 +1,9 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable import/no-unresolved */
+// react-testing-library renders your components to document.body,
+// this will ensure they're removed after each test.
+// $FlowFixMe
+import "@testing-library/react/cleanup-after-each";
+
+// this adds jest-dom's custom assertions
+import "@testing-library/jest-dom/extend-expect";


### PR DESCRIPTION
Fixes #67

I made a custom hook that will automatically try to get a user 's information when the user changes pages.
When it successfully gets the user's info, it will never recall the api again, unless you hard refresh the page.

NOTE: I had to disable an exhaustive dependency rule in a useEffect because eslint wants you to include the retry function as a depency since it's used within the useEffect. The retry function changes every time retry is called so if you include it, it'll turned into a infinite loop.
There may be a better way of handling it but I'm unsure as to how. :(